### PR TITLE
fix: find section info container bubbles to not look like buttons, header content center alignment

### DIFF
--- a/src/sass/layouts/_header.scss
+++ b/src/sass/layouts/_header.scss
@@ -36,15 +36,11 @@
   }
 
   &__logo-container {
-    margin: auto 0;
-
     &__link {
-      margin: auto 0;
-      text-decoration: none;
-      display: block;
-
       &__logo {
-        height: 4rem;
+        display: block;
+        margin: auto;
+        height: 3.5rem;
         width: 18rem;
 
         @include respond(phone) {

--- a/src/sass/pages/_home.scss
+++ b/src/sass/pages/_home.scss
@@ -433,6 +433,7 @@
 
     @include respond(phone) {
       margin-top: var(--space-8);
+      gap: var(--space-1);
     }
 
     &__info-box {
@@ -442,14 +443,28 @@
 
       &__text-box {
         display: flex;
+        position: relative;
         flex-wrap: wrap;
         padding: var(--space-1) var(--space-2);
-        border: 2px solid rgba(var(--color-gray-light-rgb), 0.45);
+        background-color: rgba(var(--color-gray-light-rgb), 0.2);
         border-radius: 2rem;
-        margin: 0 auto 0.5rem;
+        margin: 0 auto var(--space-3);
 
         @include respond(phone) {
-          padding: var(--space-05) var(--space-1);
+          padding: var(--space-1) var(--space-2);
+        }
+
+        &::after {
+          display: block;
+          content: '';
+          position: absolute;
+          background-color: rgba(var(--color-gray-light-rgb), 0.2);
+          height: 2rem;
+          width: 2rem;
+          top: 100%;
+          left: 50%;
+          transform: translateX(-50%);
+          clip-path: polygon(0 0, 50% 100%, 100% 0);
         }
 
         &--2 {
@@ -467,8 +482,8 @@
           margin-right: 1rem;
 
           @include respond(phone) {
-            height: 3.5rem;
-            width: 3.5rem;
+            height: 3.2rem;
+            width: 3.2rem;
           }
         }
 
@@ -485,7 +500,9 @@
 
       &__img-box {
         &__svg {
+          position: relative;
           height: 25rem;
+          z-index: var(--z-index-1);
 
           @include respond(phone) {
             height: 20rem;


### PR DESCRIPTION
- Centered logo and button container in the header vertically
- Find section's info containers to not look like buttons but chat bubbles