### PR TITLE
fix: add alert render handling in collection share

### DIFF
--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -314,6 +314,7 @@ const constructIndividualCollectionShareUrl = async function (collection, btn) {
       return;
     }
     const message = await helperShare(shareableUrl);
+    if (!message) return;
     IndividualCollectionView.renderToast(message, false);
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
Handled case where navogation.share works when sharing individual collection